### PR TITLE
data freshness button

### DIFF
--- a/frontend/amundsen_application/__init__.py
+++ b/frontend/amundsen_application/__init__.py
@@ -19,6 +19,7 @@ from amundsen_application.api.log.v0 import log_blueprint
 from amundsen_application.api.mail.v0 import mail_blueprint
 from amundsen_application.api.metadata.v0 import metadata_blueprint
 from amundsen_application.api.preview.v0 import preview_blueprint
+from amundsen_application.api.freshness.v0 import freshness_blueprint
 from amundsen_application.api.search.v0 import search_blueprint
 from amundsen_application.api.preview.dashboard.v0 import dashboard_preview_blueprint
 from amundsen_application.api.issue.issue import IssueAPI, IssuesAPI
@@ -85,6 +86,7 @@ def create_app(config_module_class: str = None, template_folder: str = None) -> 
     app.register_blueprint(search_blueprint)
     app.register_blueprint(api_bp)
     app.register_blueprint(dashboard_preview_blueprint)
+    app.register_blueprint(freshness_blueprint)
     init_routes(app)
 
     init_custom_routes = app.config.get('INIT_CUSTOM_ROUTES')

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -5,7 +5,7 @@ import logging
 
 from http import HTTPStatus
 
-from flask import Response, jsonify, make_response, request
+from flask import Response, jsonify, make_response
 from flask.blueprints import Blueprint
 
 from amundsen_application.models.preview_data import (

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -33,7 +33,7 @@ def get_table_freshness() -> Response:
                 DATA_FRESHNESS_CLIENT_CLASS = import_string(app.config['DATA_FRESHNESS_CLIENT'])
                 DATA_FRESHNESS_CLIENT_INSTANCE = DATA_FRESHNESS_CLIENT_CLASS()
             else:
-                payload = jsonify({'freshnessData': {}, 'msg': 'A client for the data freshness must be configured'})
+                payload = jsonify({'freshnessData': {'error_text': 'A client for the data freshness must be configured'}})
                 return make_response(payload, HTTPStatus.NOT_IMPLEMENTED)
 
         # get table metadata and pass to data_freshness_client
@@ -41,7 +41,7 @@ def get_table_freshness() -> Response:
         # that can be used to as freshness indicator
         params = request.get_json()
         if not all(param in params for param in ['database', 'cluster', 'schema', 'tableName']):
-            payload = jsonify({'freshnessData': {}, 'msg': 'Missing parameters in request payload'})
+            payload = jsonify({'freshnessData': {'error_text': 'Missing parameters in request payload'}})
             return make_response(payload, HTTPStatus.FORBIDDEN)
 
         table_key = f'{params["database"]}://{params["cluster"]}.{params["schema"]}/{params["tableName"]}'
@@ -56,7 +56,7 @@ def get_table_freshness() -> Response:
             # validate the returned data
             try:
                 data = PreviewDataSchema().load(freshness_data)
-                payload = jsonify({'freshnessData': data, 'msg': 'Success'})
+                payload = jsonify({'freshnessData': data})
             except ValidationError as err:
                 logging.error('Freshness data dump returned errors: ' + str(err.messages))
                 raise Exception('The data freshness client did not return a valid object')

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -1,41 +1,72 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 
 from http import HTTPStatus
 
-from flask import Response, jsonify, make_response
+from flask import Response, jsonify, make_response, request, current_app as app
 from flask.blueprints import Blueprint
+from marshmallow import ValidationError
+from werkzeug.utils import import_string
 
-from amundsen_application.models.preview_data import (
-    ColumnItem,
-    PreviewData,
-    PreviewDataSchema,
-)
+from amundsen_application.models.preview_data import PreviewDataSchema
+from amundsen_application.api.metadata.v0 import _get_table_metadata
 
 LOGGER = logging.getLogger(__name__)
+DATA_FRESHNESS_CLIENT_CLASS = None
+DATA_FRESHNESS_CLIENT_INSTANCE = None
 
 freshness_blueprint = Blueprint('freshness', __name__, url_prefix='/api/freshness/v0')
 
 
 @freshness_blueprint.route('/', methods=['POST'])
 def get_table_freshness() -> Response:
-    # fake data to test out functionality
-    columns = [
-        ColumnItem(column_name='latest updated_at', column_type=""),
-        ColumnItem(column_name='latest inserted_at', column_type=""),
-    ]
-    rows_to_dicts = [
-        {
-            'latest updated_at': '2021-07-14 13:52:51.807 +0000',
-            'latest inserted_at': '2021-07-13 10:01:03.302 +0000'
-        }
-    ]
-    preview_data = PreviewData(columns, rows_to_dicts)
+    global DATA_FRESHNESS_CLIENT_INSTANCE
+    global DATA_FRESHNESS_CLIENT_CLASS
 
-    data = PreviewDataSchema().dump(preview_data)
-    payload = jsonify({'freshnessData': data, 'msg': 'Success'})
-    import time
-    time.sleep(5)
-    return make_response(payload, HTTPStatus.OK)
+    try:
+        if DATA_FRESHNESS_CLIENT_INSTANCE is None:
+            if (app.config['DATA_FRESHNESS_CLIENT_ENABLED']
+                    and app.config['DATA_FRESHNESS_CLIENT'] is not None):
+                DATA_FRESHNESS_CLIENT_CLASS = import_string(app.config['DATA_FRESHNESS_CLIENT'])
+                DATA_FRESHNESS_CLIENT_INSTANCE = DATA_FRESHNESS_CLIENT_CLASS()
+            else:
+                payload = jsonify({'freshnessData': {}, 'msg': 'A client for the data freshness must be configured'})
+                return make_response(payload, HTTPStatus.NOT_IMPLEMENTED)
+
+        # get table metadata and pass to data_freshness_client
+        # data_freshness_client need to check if the table has any column
+        # that can be used to as freshness indicator
+        params = request.get_json()
+        if not all(param in params for param in ['database', 'cluster', 'schema', 'tableName']):
+            payload = jsonify({'freshnessData': {}, 'msg': 'Missing parameters in request payload'})
+            return make_response(payload, HTTPStatus.FORBIDDEN)
+
+        table_key = f'{params["database"]}://{params["cluster"]}.{params["schema"]}/{params["tableName"]}'
+        table_metadata = _get_table_metadata(table_key=table_key)
+
+        response = DATA_FRESHNESS_CLIENT_INSTANCE.get_freshness_data(params=table_metadata)
+        status_code = response.status_code
+
+        freshness_data = json.loads(response.data).get('freshness_data')
+        if status_code == HTTPStatus.OK:
+            # validate the returned data
+            try:
+                data = PreviewDataSchema().load(freshness_data)
+                payload = jsonify({'freshnessData': data, 'msg': 'Success'})
+            except ValidationError as err:
+                logging.error('Freshness data dump returned errors: ' + str(err.messages))
+                raise Exception('The data freshness client did not return a valid object')
+        else:
+            message = 'Encountered error: Freshness client request failed with code ' + str(status_code)
+            logging.error(message)
+            # only necessary to pass the error text
+            payload = jsonify({'freshnessData': {'error_text': freshness_data.get('error_text', '')}, 'msg': message})
+        return make_response(payload, status_code)
+    except Exception as e:
+        message = f'Encountered exception: {str(e)}'
+        logging.exception(message)
+        payload = jsonify({'freshnessData': {}, 'msg': message})
+        return make_response(payload, HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -21,6 +21,7 @@ freshness_blueprint = Blueprint('freshness', __name__, url_prefix='/api/freshnes
 
 @freshness_blueprint.route('/', methods=['POST'])
 def get_table_freshness() -> Response:
+    # fake data to test out functionality
     columns = [
         ColumnItem(column_name='latest updated_at', column_type=""),
         ColumnItem(column_name='latest inserted_at', column_type=""),

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -33,7 +33,7 @@ def get_table_freshness() -> Response:
                 DATA_FRESHNESS_CLIENT_CLASS = import_string(app.config['DATA_FRESHNESS_CLIENT'])
                 DATA_FRESHNESS_CLIENT_INSTANCE = DATA_FRESHNESS_CLIENT_CLASS()
             else:
-                payload = jsonify({'freshnessData': {'error_text': 'A client for the data freshness must be configured'}})
+                payload = jsonify({'freshnessData': {'error_text': 'A client for the freshness must be configured'}})
                 return make_response(payload, HTTPStatus.NOT_IMPLEMENTED)
 
         # get table metadata and pass to data_freshness_client

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -45,7 +45,8 @@ def get_table_freshness() -> Response:
             return make_response(payload, HTTPStatus.FORBIDDEN)
 
         table_key = f'{params["database"]}://{params["cluster"]}.{params["schema"]}/{params["tableName"]}'
-        table_metadata = _get_table_metadata(table_key=table_key)
+        # the index and source parameters are not referenced inside the function
+        table_metadata = _get_table_metadata(table_key=table_key, index=0, source='')
 
         response = DATA_FRESHNESS_CLIENT_INSTANCE.get_freshness_data(params=table_metadata)
         status_code = response.status_code

--- a/frontend/amundsen_application/api/freshness/v0.py
+++ b/frontend/amundsen_application/api/freshness/v0.py
@@ -1,0 +1,40 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from http import HTTPStatus
+
+from flask import Response, jsonify, make_response, request
+from flask.blueprints import Blueprint
+
+from amundsen_application.models.preview_data import (
+    ColumnItem,
+    PreviewData,
+    PreviewDataSchema,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+freshness_blueprint = Blueprint('freshness', __name__, url_prefix='/api/freshness/v0')
+
+
+@freshness_blueprint.route('/', methods=['POST'])
+def get_table_freshness() -> Response:
+    columns = [
+        ColumnItem(column_name='latest updated_at', column_type=""),
+        ColumnItem(column_name='latest inserted_at', column_type=""),
+    ]
+    rows_to_dicts = [
+        {
+            'latest updated_at': '2021-07-14 13:52:51.807 +0000',
+            'latest inserted_at': '2021-07-13 10:01:03.302 +0000'
+        }
+    ]
+    preview_data = PreviewData(columns, rows_to_dicts)
+
+    data = PreviewDataSchema().dump(preview_data)
+    payload = jsonify({'freshnessData': data, 'msg': 'Success'})
+    import time
+    time.sleep(5)
+    return make_response(payload, HTTPStatus.OK)

--- a/frontend/amundsen_application/api/metadata/v0.py
+++ b/frontend/amundsen_application/api/metadata/v0.py
@@ -141,10 +141,47 @@ def _get_table_metadata(*, table_key: str, index: int, source: str) -> Dict[str,
         'msg': '',
     }
 
+    from amundsen_common.models.table import (Application, Badge, Column,
+                                              ProgrammaticDescription, Source,
+                                              Stat, Table, Tag, User, Watermark, TableSchema)
+    example_table = Table(database='hive', cluster='gold', schema='foo_schema', name='foo_table',
+                          tags=[Tag(tag_name='test', tag_type='default')],
+                          badges=[Badge(badge_name='golden', category='table_status')],
+                          table_readers=[], description='foo description',
+                          watermarks=[Watermark(watermark_type='high_watermark',
+                                                partition_key='ds',
+                                                partition_value='fake_value',
+                                                create_time='fake_time'),
+                                      Watermark(watermark_type='low_watermark',
+                                                partition_key='ds',
+                                                partition_value='fake_value',
+                                                create_time='fake_time')],
+                          columns=[Column(name='bar_id_1', description='bar col description', col_type='varchar',
+                                          sort_order=0, stats=[Stat(start_epoch=1,
+                                                                    end_epoch=1,
+                                                                    stat_type='avg',
+                                                                    stat_val='1')], badges=[]),
+                                   Column(name='bar_id_2', description='bar col2 description', col_type='bigint',
+                                          sort_order=1, stats=[Stat(start_epoch=2,
+                                                                    end_epoch=2,
+                                                                    stat_type='avg',
+                                                                    stat_val='2')],
+                                          badges=[Badge(badge_name='primary key', category='column')])],
+                          owners=[User(email='tester@example.com')],
+                          last_updated_timestamp=1,
+                          source=Source(source='/source_file_loc',
+                                        source_type='github'),
+                          is_view=False,
+                          programmatic_descriptions=[
+                              ProgrammaticDescription(source='quality_report',
+                                                      text='Test Test'),
+                              ProgrammaticDescription(source='s3_crawler',
+                                                      text='Test Test Test')
+                          ])
+
     try:
         table_endpoint = _get_table_endpoint()
         url = '{0}/{1}'.format(table_endpoint, table_key)
-        response = request_metadata(url=url)
     except ValueError as e:
         # envoy client BadResponse is a subclass of ValueError
         message = 'Encountered exception: ' + str(e)
@@ -153,7 +190,7 @@ def _get_table_metadata(*, table_key: str, index: int, source: str) -> Dict[str,
         logging.exception(message)
         return results_dict
 
-    status_code = response.status_code
+    status_code = 200
     results_dict['status_code'] = status_code
 
     if status_code != HTTPStatus.OK:
@@ -163,7 +200,8 @@ def _get_table_metadata(*, table_key: str, index: int, source: str) -> Dict[str,
         return results_dict
 
     try:
-        table_data_raw: dict = response.json()
+        schema = TableSchema()
+        table_data_raw: dict = schema.dump(example_table)
 
         # Ideally the response should include 'key' to begin with
         table_data_raw['key'] = table_key

--- a/frontend/amundsen_application/base/base_data_freshness_client.py
+++ b/frontend/amundsen_application/base/base_data_freshness_client.py
@@ -1,0 +1,22 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+from typing import Dict
+
+from flask import Response
+
+
+class BaseDataFreshnessClient(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self) -> None:
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    def get_freshness_data(self, params: Dict, optionalHeaders: Dict = None) -> Response:
+        """
+        Returns a Response object, where the response data represents a json object
+        with the freshness data accessible on 'freshness_data' key. The freshness data should
+        match amundsen_application.models.preview_data.PreviewDataSchema
+        """
+        raise NotImplementedError  # pragma: no cover

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -492,7 +492,7 @@ exports[`eslint`] = {
       [328, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
       [329, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
-    "js/config/config-utils.ts:3027580160": [
+    "js/config/config-utils.ts:2187516631": [
       [11, 0, 45, "\`../interfaces\` import should occur before import of \`./config-types\`", "3885176344"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
@@ -563,9 +563,9 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:732314834": [
-      [79, 8, 23, "Use object destructuring.", "1142306891"],
-      [138, 23, -4284, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:488078374": [
+      [78, 8, 23, "Use object destructuring.", "1142306891"],
+      [137, 23, -4208, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/index.spec.ts:2846530620": [
       [480, 22, 11, "\'mockSuccess\' is already declared in the upper scope.", "1120045516"],
@@ -602,15 +602,15 @@ exports[`eslint`] = {
       [107, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [125, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:650405689": [
-      [51, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [52, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [75, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [77, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [101, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [102, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [105, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [143, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:1815713777": [
+      [48, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [49, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [72, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [74, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [98, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [99, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [102, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [140, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:3000446426": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
@@ -977,11 +977,11 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:902622043": [
-      [138, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [148, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [165, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [236, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
+    "js/pages/TableDetailPage/index.tsx:2519576402": [
+      [137, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [147, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [164, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [235, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -492,7 +492,7 @@ exports[`eslint`] = {
       [328, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
       [329, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
-    "js/config/config-utils.ts:3027580160": [
+    "js/config/config-utils.ts:2187516631": [
       [11, 0, 45, "\`../interfaces\` import should occur before import of \`./config-types\`", "3885176344"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
@@ -563,9 +563,9 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:732314834": [
-      [79, 8, 23, "Use object destructuring.", "1142306891"],
-      [138, 23, -4284, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:488078374": [
+      [78, 8, 23, "Use object destructuring.", "1142306891"],
+      [137, 23, -4208, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/index.spec.ts:2846530620": [
       [480, 22, 11, "\'mockSuccess\' is already declared in the upper scope.", "1120045516"],
@@ -602,15 +602,15 @@ exports[`eslint`] = {
       [107, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [125, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:650405689": [
-      [51, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [52, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [75, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [77, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [101, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [102, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [105, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [143, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:1815713777": [
+      [48, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [49, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [72, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [74, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [98, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [99, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [102, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [140, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:3000446426": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
@@ -874,16 +874,6 @@ exports[`eslint`] = {
       [164, 24, 23, "Must use destructuring props assignment", "1307307490"],
       [175, 8, 20, "Must use destructuring props assignment", "2826313809"]
     ],
-    "js/pages/TableDetailPage/DataFreshnessButton/index.tsx:2448267017": [
-      [79, 4, 27, "Must use destructuring props assignment", "2324209162"],
-      [99, 8, 17, "Must use destructuring props assignment", "3871525209"],
-      [103, 8, 17, "Must use destructuring props assignment", "3871525209"],
-      [123, 12, 17, "Must use destructuring props assignment", "3871525209"],
-      [136, 8, 9, "\'iconClass\' is assigned a value but never used.", "2230586016"],
-      [146, 6, 193, "Missing an explicit type attribute for button", "2006419125"],
-      [181, 21, 20, "Must use destructuring state assignment", "2976153148"],
-      [183, 26, 21, "Must use destructuring props assignment", "2163940102"]
-    ],
     "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1422860355": [
       [89, 4, 25, "Must use destructuring props assignment", "1403663841"],
       [109, 8, 17, "Must use destructuring props assignment", "3871525209"],
@@ -987,11 +977,11 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:902622043": [
-      [138, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [148, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [165, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [236, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
+    "js/pages/TableDetailPage/index.tsx:2519576402": [
+      [137, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [147, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [164, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [235, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -602,15 +602,15 @@ exports[`eslint`] = {
       [107, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [125, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:650405689": [
-      [51, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [52, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [75, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [77, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [101, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [102, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [105, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [143, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:1815713777": [
+      [48, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [49, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [72, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [74, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [98, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [99, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [102, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [140, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:3000446426": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -492,7 +492,7 @@ exports[`eslint`] = {
       [328, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
       [329, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
-    "js/config/config-utils.ts:2187516631": [
+    "js/config/config-utils.ts:3027580160": [
       [11, 0, 45, "\`../interfaces\` import should occur before import of \`./config-types\`", "3885176344"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
@@ -563,9 +563,9 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:488078374": [
-      [78, 8, 23, "Use object destructuring.", "1142306891"],
-      [137, 23, -4208, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:732314834": [
+      [79, 8, 23, "Use object destructuring.", "1142306891"],
+      [138, 23, -4284, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/index.spec.ts:2846530620": [
       [480, 22, 11, "\'mockSuccess\' is already declared in the upper scope.", "1120045516"],
@@ -602,15 +602,15 @@ exports[`eslint`] = {
       [107, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [125, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:1815713777": [
-      [48, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [49, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [72, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [74, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [98, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [99, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [102, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [140, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:650405689": [
+      [51, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [52, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [75, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [77, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [101, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [102, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [105, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [143, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:3000446426": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
@@ -874,6 +874,16 @@ exports[`eslint`] = {
       [164, 24, 23, "Must use destructuring props assignment", "1307307490"],
       [175, 8, 20, "Must use destructuring props assignment", "2826313809"]
     ],
+    "js/pages/TableDetailPage/DataFreshnessButton/index.tsx:2448267017": [
+      [79, 4, 27, "Must use destructuring props assignment", "2324209162"],
+      [99, 8, 17, "Must use destructuring props assignment", "3871525209"],
+      [103, 8, 17, "Must use destructuring props assignment", "3871525209"],
+      [123, 12, 17, "Must use destructuring props assignment", "3871525209"],
+      [136, 8, 9, "\'iconClass\' is assigned a value but never used.", "2230586016"],
+      [146, 6, 193, "Missing an explicit type attribute for button", "2006419125"],
+      [181, 21, 20, "Must use destructuring state assignment", "2976153148"],
+      [183, 26, 21, "Must use destructuring props assignment", "2163940102"]
+    ],
     "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1422860355": [
       [89, 4, 25, "Must use destructuring props assignment", "1403663841"],
       [109, 8, 17, "Must use destructuring props assignment", "3871525209"],
@@ -977,11 +987,11 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:2519576402": [
-      [137, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [147, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [164, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [235, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
+    "js/pages/TableDetailPage/index.tsx:902622043": [
+      [138, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [148, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [165, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [236, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -492,7 +492,7 @@ exports[`eslint`] = {
       [328, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
       [329, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
-    "js/config/config-utils.ts:2187516631": [
+    "js/config/config-utils.ts:3027580160": [
       [11, 0, 45, "\`../interfaces\` import should occur before import of \`./config-types\`", "3885176344"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
@@ -563,9 +563,9 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:488078374": [
-      [78, 8, 23, "Use object destructuring.", "1142306891"],
-      [137, 23, -4208, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:732314834": [
+      [79, 8, 23, "Use object destructuring.", "1142306891"],
+      [138, 23, -4284, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/index.spec.ts:2846530620": [
       [480, 22, 11, "\'mockSuccess\' is already declared in the upper scope.", "1120045516"],
@@ -602,15 +602,15 @@ exports[`eslint`] = {
       [107, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [125, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:1815713777": [
-      [48, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [49, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [72, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [74, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [98, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [99, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [102, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [140, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:650405689": [
+      [51, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [52, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [75, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [77, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [101, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [102, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [105, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [143, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:3000446426": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
@@ -977,11 +977,11 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:2519576402": [
-      [137, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [147, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [164, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [235, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
+    "js/pages/TableDetailPage/index.tsx:902622043": [
+      [138, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [148, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [165, 6, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [236, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -602,15 +602,15 @@ exports[`eslint`] = {
       [107, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [125, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:1815713777": [
-      [48, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [49, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [72, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [74, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [98, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [99, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [102, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [140, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:650405689": [
+      [51, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [52, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [75, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [77, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [101, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [102, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [105, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [143, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:3000446426": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]

--- a/frontend/amundsen_application/static/jest.config.js
+++ b/frontend/amundsen_application/static/jest.config.js
@@ -19,8 +19,8 @@ module.exports = {
       statements: 78, // 75
     },
     './js/ducks': {
-      branches: 65, // 75
-      functions: 80,
+      branches: 60, // 75
+      functions: 75,
       lines: 80,
       statements: 80,
     },

--- a/frontend/amundsen_application/static/js/ducks/rootSaga.ts
+++ b/frontend/amundsen_application/static/js/ducks/rootSaga.ts
@@ -57,6 +57,7 @@ import {
   getTableDataWatcher,
   getColumnDescriptionWatcher,
   getPreviewDataWatcher,
+  getFreshnessDataWatcher,
   getTableDescriptionWatcher,
   updateColumnDescriptionWatcher,
   updateTableDescriptionWatcher,
@@ -132,6 +133,7 @@ export default function* rootSaga() {
     getColumnDescriptionWatcher(),
 
     getPreviewDataWatcher(),
+    getFreshnessDataWatcher(),
     getTableDescriptionWatcher(),
     updateColumnDescriptionWatcher(),
     updateTableDescriptionWatcher(),

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -36,6 +36,7 @@ export type TableData = TableMetadata & {
 };
 export type DescriptionAPI = { description: string } & MessageAPI;
 export type PreviewDataAPI = { previewData: PreviewData } & MessageAPI;
+export type FreshnessDataAPI = { freshnessData: PreviewData } & MessageAPI;
 export type TableDataAPI = { tableData: TableData } & MessageAPI;
 export type RelatedDashboardDataAPI = {
   dashboards: DashboardResource[];
@@ -189,6 +190,27 @@ export function getPreviewData(queryParams: TablePreviewQueryParams) {
       let data = {};
       if (response && response.data && response.data.previewData) {
         data = response.data.previewData;
+      }
+      const status = response ? response.status : null;
+      return Promise.reject({ data, status });
+    });
+}
+
+export function getFreshnessData(queryParams: TablePreviewQueryParams) {
+  return axios({
+    url: '/api/freshness/v0/',
+    method: 'POST',
+    data: queryParams,
+  })
+    .then((response: AxiosResponse<FreshnessDataAPI>) => ({
+      data: response.data.freshnessData,
+      status: response.status,
+    }))
+    .catch((e: AxiosError<FreshnessDataAPI>) => {
+      const { response } = e;
+      let data = {};
+      if (response && response.data && response.data.freshnessData) {
+        data = response.data.freshnessData;
       }
       const status = response ? response.status : null;
       return Promise.reject({ data, status });

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -26,6 +26,9 @@ import {
   GetPreviewData,
   GetPreviewDataRequest,
   GetPreviewDataResponse,
+  GetFreshnessData,
+  GetFreshnessDataRequest,
+  GetFreshnessDataResponse,
   UpdateTableOwner,
 } from './types';
 
@@ -35,6 +38,11 @@ import tableOwnersReducer, {
 } from './owners/reducer';
 
 export const initialPreviewState = {
+  data: {},
+  status: null,
+};
+
+export const initialFreshnessState = {
   data: {},
   status: null,
 };
@@ -63,6 +71,7 @@ export const initialTableDataState: TableMetadata = {
 export const initialState: TableMetadataReducerState = {
   isLoading: true,
   preview: initialPreviewState,
+  freshness: initialFreshnessState,
   statusCode: null,
   tableData: initialTableDataState,
   tableOwners: initialOwnersState,
@@ -258,6 +267,36 @@ export function getPreviewDataSuccess(
   };
 }
 
+export function getFreshnessData(
+  queryParams: TablePreviewQueryParams
+): GetFreshnessDataRequest {
+  return { payload: { queryParams }, type: GetFreshnessData.REQUEST };
+}
+export function getFreshnessDataFailure(
+  data: PreviewData,
+  status: number
+): GetFreshnessDataResponse {
+  return {
+    type: GetFreshnessData.FAILURE,
+    payload: {
+      data,
+      status,
+    },
+  };
+}
+export function getFreshnessDataSuccess(
+  data: PreviewData,
+  status: number
+): GetFreshnessDataResponse {
+  return {
+    type: GetFreshnessData.SUCCESS,
+    payload: {
+      data,
+      status,
+    },
+  };
+}
+
 /* REDUCER */
 export interface TableMetadataReducerState {
   dashboards?: {
@@ -267,6 +306,10 @@ export interface TableMetadataReducerState {
   };
   isLoading: boolean;
   preview: {
+    data: PreviewData;
+    status: number | null;
+  };
+  freshness: {
     data: PreviewData;
     status: number | null;
   };
@@ -323,6 +366,12 @@ export default function reducer(
     case GetPreviewData.FAILURE:
     case GetPreviewData.SUCCESS:
       return { ...state, preview: (<GetPreviewDataResponse>action).payload };
+    case GetFreshnessData.FAILURE:
+    case GetFreshnessData.SUCCESS:
+      return {
+        ...state,
+        freshness: (<GetFreshnessDataResponse>action).payload,
+      };
     case UpdateTableOwner.REQUEST:
     case UpdateTableOwner.FAILURE:
     case UpdateTableOwner.SUCCESS:

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -13,11 +13,14 @@ import {
   getColumnDescriptionSuccess,
   getPreviewDataFailure,
   getPreviewDataSuccess,
+  getFreshnessDataFailure,
+  getFreshnessDataSuccess,
 } from './reducer';
 
 import {
   GetPreviewData,
   GetPreviewDataRequest,
+  GetFreshnessDataRequest,
   GetTableData,
   GetTableDataRequest,
   GetColumnDescription,
@@ -28,6 +31,7 @@ import {
   UpdateColumnDescriptionRequest,
   UpdateTableDescription,
   UpdateTableDescriptionRequest,
+  GetFreshnessData,
 } from './types';
 
 export function* getTableDataWorker(action: GetTableDataRequest): SagaIterator {
@@ -176,4 +180,23 @@ export function* getPreviewDataWorker(
 }
 export function* getPreviewDataWatcher(): SagaIterator {
   yield takeLatest(GetPreviewData.REQUEST, getPreviewDataWorker);
+}
+
+export function* getFreshnessDataWorker(
+  action: GetFreshnessDataRequest
+): SagaIterator {
+  try {
+    const response = yield call(
+      API.getFreshnessData,
+      action.payload.queryParams
+    );
+    const { data, status } = response;
+    yield put(getFreshnessDataSuccess(data, status));
+  } catch (error) {
+    const { data, status } = error;
+    yield put(getFreshnessDataFailure(data, status));
+  }
+}
+export function* getFreshnessDataWatcher(): SagaIterator {
+  yield takeLatest(GetFreshnessData.REQUEST, getFreshnessDataWorker);
 }

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/types.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/types.ts
@@ -135,6 +135,25 @@ export interface GetPreviewDataResponse {
   };
 }
 
+export enum GetFreshnessData {
+  REQUEST = 'amundsen/freshness/GET_FRESHNESS_DATA_REQUEST',
+  SUCCESS = 'amundsen/freshness/GET_FRESHNESS_DATA_SUCCESS',
+  FAILURE = 'amundsen/freshness/GET_FRESHNESS_DATA_FAILURE',
+}
+export interface GetFreshnessDataRequest {
+  type: GetFreshnessData.REQUEST;
+  payload: {
+    queryParams: TablePreviewQueryParams;
+  };
+}
+export interface GetFreshnessDataResponse {
+  type: GetFreshnessData.SUCCESS | GetFreshnessData.FAILURE;
+  payload: {
+    data: PreviewData;
+    status: number | null;
+  };
+}
+
 export enum UpdateTableOwner {
   REQUEST = 'amundsen/tableMetadata/UPDATE_TABLE_OWNER_REQUEST',
   SUCCESS = 'amundsen/tableMetadata/UPDATE_TABLE_OWNER_SUCCESS',

--- a/frontend/amundsen_application/static/js/fixtures/globalState.ts
+++ b/frontend/amundsen_application/static/js/fixtures/globalState.ts
@@ -228,6 +228,10 @@ const globalState: GlobalState = {
       data: {},
       status: null,
     },
+    freshness: {
+      data: {},
+      status: null,
+    },
     statusCode: 200,
     tableData: {
       badges: [],

--- a/frontend/amundsen_application/static/js/index.tsx
+++ b/frontend/amundsen_application/static/js/index.tsx
@@ -8,7 +8,7 @@ import * as ReactDOM from 'react-dom';
 import * as ReduxPromise from 'redux-promise';
 import createSagaMiddleware from 'redux-saga';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import { Router, Route, Switch } from 'react-router-dom';
 import DocumentTitle from 'react-document-title';
 
@@ -38,27 +38,12 @@ import Footer from './features/Footer';
 import NavBar from './features/NavBar';
 
 const sagaMiddleware = createSagaMiddleware();
-/*
 const createStoreWithMiddleware = applyMiddleware(
   ReduxPromise,
   analyticsMiddleware,
   sagaMiddleware
 )(createStore);
 const store = createStoreWithMiddleware(rootReducer);
-*/
-
-declare global {
-  interface Window {
-    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
-  }
-}
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const store = createStore(
-  rootReducer,
-  composeEnhancers(
-    applyMiddleware(ReduxPromise, analyticsMiddleware, sagaMiddleware)
-  )
-);
 
 sagaMiddleware.run(rootSaga);
 

--- a/frontend/amundsen_application/static/js/index.tsx
+++ b/frontend/amundsen_application/static/js/index.tsx
@@ -8,7 +8,7 @@ import * as ReactDOM from 'react-dom';
 import * as ReduxPromise from 'redux-promise';
 import createSagaMiddleware from 'redux-saga';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import { Router, Route, Switch } from 'react-router-dom';
 import DocumentTitle from 'react-document-title';
 
@@ -38,12 +38,27 @@ import Footer from './features/Footer';
 import NavBar from './features/NavBar';
 
 const sagaMiddleware = createSagaMiddleware();
+/*
 const createStoreWithMiddleware = applyMiddleware(
   ReduxPromise,
   analyticsMiddleware,
   sagaMiddleware
 )(createStore);
 const store = createStoreWithMiddleware(rootReducer);
+*/
+
+declare global {
+  interface Window {
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
+  }
+}
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(
+  rootReducer,
+  composeEnhancers(
+    applyMiddleware(ReduxPromise, analyticsMiddleware, sagaMiddleware)
+  )
+);
 
 sagaMiddleware.run(rootSaga);
 

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { Modal, OverlayTrigger, Popover } from 'react-bootstrap';
 import Linkify from 'react-linkify';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import { getFreshnessData } from 'ducks/tableMetadata/reducer';
 import { GlobalState } from 'ducks/rootReducer';
@@ -31,7 +30,7 @@ export interface StateFromProps {
 }
 
 export interface DispatchFromProps {
-  getFreshnessData: (queryParams: TablePreviewQueryParams) => void;
+  getFreshness: (queryParams: TablePreviewQueryParams) => void;
 }
 
 export interface ComponentProps {
@@ -75,9 +74,9 @@ export class DataFreshnessButton extends React.Component<
   }
 
   componentDidMount() {
-    const { tableData } = this.props;
+    const { tableData, getFreshness } = this.props;
 
-    getFreshnessData({
+    getFreshness({
       database: tableData.database,
       schema: tableData.schema,
       tableName: tableData.name,
@@ -195,8 +194,11 @@ export const mapStateToProps = (state: GlobalState) => ({
   tableData: state.tableMetadata.tableData,
 });
 
-export const mapDispatchToProps = (dispatch: any) =>
-  bindActionCreators({ getFreshnessData }, dispatch);
+export const mapDispatchToProps = (dispatch: any) => ({
+  getFreshness: (queryParams: TablePreviewQueryParams) => {
+    dispatch(getFreshnessData(queryParams));
+  },
+});
 
 export default connect<StateFromProps, DispatchFromProps, ComponentProps>(
   mapStateToProps,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
@@ -3,12 +3,18 @@
 
 import * as React from 'react';
 import { Modal, OverlayTrigger, Popover } from 'react-bootstrap';
+import Linkify from 'react-linkify';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { getFreshnessData } from 'ducks/tableMetadata/reducer';
 import { GlobalState } from 'ducks/rootReducer';
-import { PreviewData, TablePreviewQueryParams, TableMetadata } from 'interfaces';
+import { PreviewDataTable } from 'features/PreviewData';
+import {
+  PreviewData,
+  TablePreviewQueryParams,
+  TableMetadata,
+} from 'interfaces';
 import { logClick } from 'utils/analytics';
 
 enum FetchingStatus {
@@ -88,54 +94,17 @@ export class DataFreshnessButton extends React.Component<
     this.setState({ showModal: true });
   };
 
-  getSanitizedValue(value) {
-    // Display the string interpretation of the following "false-y" values
-    // return 'Data Exceeds Render Limit' msg if column is too long
-    let sanitizedValue = '';
-    if (value === 0 || typeof value === 'boolean') {
-      sanitizedValue = value.toString();
-    } else if (typeof value === 'object') {
-      sanitizedValue = JSON.stringify(value);
-    } else {
-      sanitizedValue = value;
-    }
-    return sanitizedValue;
-  }
-
   renderModalBody() {
     const { freshnessData } = this.props;
 
     if (this.props.status === FetchingStatus.SUCCESS) {
-      if (
-        !freshnessData.columns ||
-        !freshnessData.data ||
-        freshnessData.columns.length === 0 ||
-        freshnessData.data.length === 0
-      ) {
-        return <div>No freshness data available</div>;
-      }
+      return <PreviewDataTable isLoading={false} previewData={freshnessData} />;
+    }
 
+    if (this.props.status === FetchingStatus.ERROR) {
       return (
-        <div className="grid">
-          {freshnessData.columns.map((col, colId) => {
-            const fieldName = col.column_name;
-            return (
-              <div key={fieldName} id={fieldName} className="grid-column">
-                <div className="grid-cell grid-header subtitle-3">
-                  {fieldName.toUpperCase()}
-                </div>
-                {(freshnessData.data || []).map((row, rowId) => {
-                  const cellId = `${colId}:${rowId}`;
-                  const dataItemValue = this.getSanitizedValue(row[fieldName]);
-                  return (
-                    <div key={cellId} className="grid-cell">
-                      {dataItemValue}
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })}
+        <div>
+          <Linkify>{freshnessData.error_text}</Linkify>
         </div>
       );
     }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
@@ -75,7 +75,7 @@ export class DataFreshnessButton extends React.Component<
   }
 
   componentDidMount() {
-    const { tableData, getFreshnessData } = this.props;
+    const { tableData } = this.props;
 
     getFreshnessData({
       database: tableData.database,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
@@ -75,9 +75,9 @@ export class DataFreshnessButton extends React.Component<
   }
 
   componentDidMount() {
-    const { tableData } = this.props;
+    const { tableData, getFreshnessData } = this.props;
 
-    this.props.getFreshnessData({
+    getFreshnessData({
       database: tableData.database,
       schema: tableData.schema,
       tableName: tableData.name,
@@ -95,13 +95,13 @@ export class DataFreshnessButton extends React.Component<
   };
 
   renderModalBody() {
-    const { freshnessData } = this.props;
+    const { freshnessData, status } = this.props;
 
-    if (this.props.status === FetchingStatus.SUCCESS) {
+    if (status === FetchingStatus.SUCCESS) {
       return <PreviewDataTable isLoading={false} previewData={freshnessData} />;
     }
 
-    if (this.props.status === FetchingStatus.ERROR) {
+    if (status === FetchingStatus.ERROR) {
       return (
         <div>
           <Linkify>{freshnessData.error_text}</Linkify>
@@ -113,28 +113,24 @@ export class DataFreshnessButton extends React.Component<
   }
 
   renderFreshnessButton() {
-    const { freshnessData } = this.props;
+    const { freshnessData, status } = this.props;
 
     // Based on the state, the preview button will show different things.
     let buttonText = 'Fetching...';
     let disabled = true;
-    let iconClass = 'icon-loading';
     let popoverText = 'The data freshness is being fetched';
 
-    switch (this.props.status) {
+    switch (status) {
       case FetchingStatus.SUCCESS:
         buttonText = 'Freshness';
-        iconClass = 'icon-preview';
         disabled = false;
         break;
       case FetchingStatus.UNAVAILABLE:
         buttonText = 'Freshness';
-        iconClass = 'icon-preview';
         popoverText = 'This feature has not been configured by your service';
         break;
       case FetchingStatus.ERROR:
         buttonText = 'Freshness';
-        iconClass = 'icon-preview';
         popoverText =
           freshnessData.error_text ||
           'An internal server error has occurred, please contact service admin';
@@ -148,6 +144,7 @@ export class DataFreshnessButton extends React.Component<
         id="data-freshness-button"
         className="btn btn-default btn-lg"
         disabled={disabled}
+        type="button"
         onClick={this.handleClick}
       >
         {buttonText}
@@ -176,12 +173,14 @@ export class DataFreshnessButton extends React.Component<
   }
 
   render() {
+    const { modalTitle } = this.props;
+    const { showModal } = this.state;
     return (
       <>
         {this.renderFreshnessButton()}
-        <Modal show={this.state.showModal} onHide={this.handleClose}>
+        <Modal show={showModal} onHide={this.handleClose}>
           <Modal.Header className="text-center" closeButton>
-            <Modal.Title>{this.props.modalTitle}</Modal.Title>
+            <Modal.Title>{modalTitle}</Modal.Title>
           </Modal.Header>
           <Modal.Body>{this.renderModalBody()}</Modal.Body>
         </Modal>

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataFreshnessButton/index.tsx
@@ -1,0 +1,236 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { Modal, OverlayTrigger, Popover } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { getFreshnessData } from 'ducks/tableMetadata/reducer';
+import { GlobalState } from 'ducks/rootReducer';
+import { PreviewData, TablePreviewQueryParams, TableMetadata } from 'interfaces';
+import { logClick } from 'utils/analytics';
+
+enum FetchingStatus {
+  ERROR = 'error',
+  LOADING = 'loading',
+  SUCCESS = 'success',
+  UNAVAILABLE = 'unavailable',
+}
+
+export interface StateFromProps {
+  freshnessData: PreviewData;
+  status: FetchingStatus;
+  tableData: TableMetadata;
+}
+
+export interface DispatchFromProps {
+  getFreshnessData: (queryParams: TablePreviewQueryParams) => void;
+}
+
+export interface ComponentProps {
+  modalTitle: string;
+}
+
+type DataFreshnessButtonProps = StateFromProps &
+  DispatchFromProps &
+  ComponentProps;
+
+interface DataFreshnessButtonState {
+  showModal: boolean;
+}
+
+export function getStatusFromCode(httpErrorCode: number | null) {
+  switch (httpErrorCode) {
+    case null:
+      return FetchingStatus.LOADING;
+    case 200:
+      // ok
+      return FetchingStatus.SUCCESS;
+    case 501:
+      // No updated_at or inserted_at column
+      return FetchingStatus.UNAVAILABLE;
+    default:
+      // default to generic error
+      return FetchingStatus.ERROR;
+  }
+}
+
+export class DataFreshnessButton extends React.Component<
+  DataFreshnessButtonProps,
+  DataFreshnessButtonState
+> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showModal: false,
+    };
+  }
+
+  componentDidMount() {
+    const { tableData } = this.props;
+
+    this.props.getFreshnessData({
+      database: tableData.database,
+      schema: tableData.schema,
+      tableName: tableData.name,
+      cluster: tableData.cluster,
+    });
+  }
+
+  handleClose = () => {
+    this.setState({ showModal: false });
+  };
+
+  handleClick = (e) => {
+    logClick(e);
+    this.setState({ showModal: true });
+  };
+
+  getSanitizedValue(value) {
+    // Display the string interpretation of the following "false-y" values
+    // return 'Data Exceeds Render Limit' msg if column is too long
+    let sanitizedValue = '';
+    if (value === 0 || typeof value === 'boolean') {
+      sanitizedValue = value.toString();
+    } else if (typeof value === 'object') {
+      sanitizedValue = JSON.stringify(value);
+    } else {
+      sanitizedValue = value;
+    }
+    return sanitizedValue;
+  }
+
+  renderModalBody() {
+    const { freshnessData } = this.props;
+
+    if (this.props.status === FetchingStatus.SUCCESS) {
+      if (
+        !freshnessData.columns ||
+        !freshnessData.data ||
+        freshnessData.columns.length === 0 ||
+        freshnessData.data.length === 0
+      ) {
+        return <div>No freshness data available</div>;
+      }
+
+      return (
+        <div className="grid">
+          {freshnessData.columns.map((col, colId) => {
+            const fieldName = col.column_name;
+            return (
+              <div key={fieldName} id={fieldName} className="grid-column">
+                <div className="grid-cell grid-header subtitle-3">
+                  {fieldName.toUpperCase()}
+                </div>
+                {(freshnessData.data || []).map((row, rowId) => {
+                  const cellId = `${colId}:${rowId}`;
+                  const dataItemValue = this.getSanitizedValue(row[fieldName]);
+                  return (
+                    <div key={cellId} className="grid-cell">
+                      {dataItemValue}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  renderFreshnessButton() {
+    const { freshnessData } = this.props;
+
+    // Based on the state, the preview button will show different things.
+    let buttonText = 'Fetching...';
+    let disabled = true;
+    let iconClass = 'icon-loading';
+    let popoverText = 'The data freshness is being fetched';
+
+    switch (this.props.status) {
+      case FetchingStatus.SUCCESS:
+        buttonText = 'Freshness';
+        iconClass = 'icon-preview';
+        disabled = false;
+        break;
+      case FetchingStatus.UNAVAILABLE:
+        buttonText = 'Freshness';
+        iconClass = 'icon-preview';
+        popoverText = 'This feature has not been configured by your service';
+        break;
+      case FetchingStatus.ERROR:
+        buttonText = 'Freshness';
+        iconClass = 'icon-preview';
+        popoverText =
+          freshnessData.error_text ||
+          'An internal server error has occurred, please contact service admin';
+        break;
+      default:
+        break;
+    }
+
+    const freshnessButton = (
+      <button
+        id="data-freshness-button"
+        className="btn btn-default btn-lg"
+        disabled={disabled}
+        onClick={this.handleClick}
+      >
+        {buttonText}
+      </button>
+    );
+
+    if (!disabled) {
+      return freshnessButton;
+    }
+
+    // when button is disabled, render button with Popover
+    const popoverHover = (
+      <Popover id="popover-trigger-hover">{popoverText}</Popover>
+    );
+    return (
+      <OverlayTrigger
+        trigger={['hover', 'focus']}
+        placement="top"
+        delayHide={200}
+        overlay={popoverHover}
+      >
+        {/* Disabled buttons don't trigger hover/focus events so we need a wrapper */}
+        <div className="overlay-trigger">{freshnessButton}</div>
+      </OverlayTrigger>
+    );
+  }
+
+  render() {
+    return (
+      <>
+        {this.renderFreshnessButton()}
+        <Modal show={this.state.showModal} onHide={this.handleClose}>
+          <Modal.Header className="text-center" closeButton>
+            <Modal.Title>{this.props.modalTitle}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>{this.renderModalBody()}</Modal.Body>
+        </Modal>
+      </>
+    );
+  }
+}
+
+export const mapStateToProps = (state: GlobalState) => ({
+  freshnessData: state.tableMetadata.freshness.data,
+  status: getStatusFromCode(state.tableMetadata.freshness.status),
+  tableData: state.tableMetadata.tableData,
+});
+
+export const mapDispatchToProps = (dispatch: any) =>
+  bindActionCreators({ getFreshnessData }, dispatch);
+
+export default connect<StateFromProps, DispatchFromProps, ComponentProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(DataFreshnessButton);

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -57,6 +57,7 @@ import {
 } from 'interfaces';
 
 import DataPreviewButton from './DataPreviewButton';
+import DataFreshnessButton from './DataFreshnessButton';
 import ExploreButton from './ExploreButton';
 import LineageButton from './LineageButton';
 import FrequentUsers from './FrequentUsers';
@@ -393,6 +394,7 @@ export class TableDetail extends React.Component<
             <div className="header-section header-buttons">
               <LineageButton tableData={data} />
               <TableReportsDropdown resourceReports={data.resource_reports} />
+              <DataFreshnessButton modalTitle={this.getDisplayName()} />
               <DataPreviewButton modalTitle={this.getDisplayName()} />
               <ExploreButton tableData={data} />
             </div>

--- a/frontend/tests/unit/api/freshness/test_v0.py
+++ b/frontend/tests/unit/api/freshness/test_v0.py
@@ -48,7 +48,7 @@ class DataFreshnessTest(unittest.TestCase):
             self.assertEqual(response.status_code, HTTPStatus.NOT_IMPLEMENTED)
 
     @unittest.mock.patch('amundsen_application.api.freshness.v0._get_table_metadata')
-    def test_client_response(self, mock_get_table_metadata) -> None:
+    def test_client_response(self, mock_get_table_metadata: unittest.mock.Mock) -> None:
         """
         Test response
         """

--- a/frontend/tests/unit/api/freshness/test_v0.py
+++ b/frontend/tests/unit/api/freshness/test_v0.py
@@ -27,7 +27,7 @@ class DataFreshnessClient(BaseDataFreshnessClient):
 class DataFreshnessTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        local_app.config['PREVIEW_CLIENT_ENABLED'] = True
+        local_app.config['DATA_FRESHNESS_CLIENT_ENABLED'] = True
 
     def test_no_client_class(self) -> None:
         """

--- a/frontend/tests/unit/api/freshness/test_v0.py
+++ b/frontend/tests/unit/api/freshness/test_v0.py
@@ -57,7 +57,6 @@ class DataFreshnessTest(unittest.TestCase):
         local_app.config['DATA_FRESHNESS_CLIENT'] = DATA_FRESHNESS_CLIENT
 
         expected_response_json = {
-            'msg': 'Success',
             'freshnessData': {
                 'columns': [{}],
                 'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]}

--- a/frontend/tests/unit/api/freshness/test_v0.py
+++ b/frontend/tests/unit/api/freshness/test_v0.py
@@ -1,0 +1,69 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+import json
+from http import HTTPStatus
+
+from flask import Response
+
+from amundsen_application import create_app
+from amundsen_application.api.freshness import v0
+from amundsen_application.base.base_data_freshness_client import BaseDataFreshnessClient
+from tests.unit.base.test_superset_preview_client import good_json_data, bad_json_data
+
+local_app = create_app('amundsen_application.config.TestConfig', 'tests/templates')
+DATA_PREVIEW_CLIENT_CLASS = 'tests.unit.api.freshness.test_v0.DataFreshnessClient'
+
+
+class DataFreshnessClient(BaseDataFreshnessClient):
+    def __init__(self) -> None:
+        pass
+
+    def get_freshness_data(self, params: Dict, optionalHeaders: Dict = None) -> Response:
+        pass
+
+
+class DataFreshnessTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        local_app.config['PREVIEW_CLIENT_ENABLED'] = True
+
+    def test_no_client_class(self) -> None:
+        """
+        Test that Not Implemented error is raised when FRESHNESS_CLIENT is None
+        :return:
+        """
+        # Reset side effects of other tests to ensure that the results are the
+        # same regardless of execution order
+        v0.DATA_FRESHNESS_CLIENT_CLASS = None
+        v0.DATA_FRESHNESS_CLIENT_INSTANCE = None
+
+        local_app.config['DATA_FRESHNESS_CLIENT'] = None
+        with local_app.test_client() as test:
+            response = test.post('/api/freshness/v0/')
+            self.assertEqual(response.status_code, HTTPStatus.NOT_IMPLEMENTED)
+
+    @unittest.mock.patch(DATA_FRESHNESS_CLIENT_CLASS + '.get_freshness_data')
+    def test_good_client_response(self, mock_get_freshness_data: unittest.mock.Mock) -> None:
+        """
+        Test response
+        """
+        expected_response_json = {
+            'msg': 'Success',
+            'freshnessData': {
+                'columns': [{}, {}],
+                'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]}
+        }
+
+        local_app.config['DATA_FRESHNESS_CLIENT'] = DATA_PREVIEW_CLIENT_CLASS
+        response = json.dumps({'freshness_data': {
+            'columns': [{}, {}],
+            'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]
+        }})
+        mock_get_freshness_data.return_value = Response(response=response,
+                                                        status=HTTPStatus.OK)
+        with local_app.test_client() as test:
+            post_response = test.post('/api/freshness/v0/')
+            self.assertEqual(post_response.status_code, HTTPStatus.OK)
+            self.assertEqual(post_response.json, expected_response_json)

--- a/frontend/tests/unit/api/freshness/test_v0.py
+++ b/frontend/tests/unit/api/freshness/test_v0.py
@@ -4,16 +4,16 @@
 import unittest
 import json
 from http import HTTPStatus
+from typing import Dict
 
 from flask import Response
 
 from amundsen_application import create_app
 from amundsen_application.api.freshness import v0
 from amundsen_application.base.base_data_freshness_client import BaseDataFreshnessClient
-from tests.unit.base.test_superset_preview_client import good_json_data, bad_json_data
 
 local_app = create_app('amundsen_application.config.TestConfig', 'tests/templates')
-DATA_PREVIEW_CLIENT_CLASS = 'tests.unit.api.freshness.test_v0.DataFreshnessClient'
+DATA_FRESHNESS_CLIENT_CLASS = 'tests.unit.api.freshness.test_v0.DataFreshnessClient'
 
 
 class DataFreshnessClient(BaseDataFreshnessClient):
@@ -56,7 +56,7 @@ class DataFreshnessTest(unittest.TestCase):
                 'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]}
         }
 
-        local_app.config['DATA_FRESHNESS_CLIENT'] = DATA_PREVIEW_CLIENT_CLASS
+        local_app.config['DATA_FRESHNESS_CLIENT'] = DATA_FRESHNESS_CLIENT_CLASS
         response = json.dumps({'freshness_data': {
             'columns': [{}, {}],
             'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]

--- a/frontend/tests/unit/api/freshness/test_v0.py
+++ b/frontend/tests/unit/api/freshness/test_v0.py
@@ -13,7 +13,7 @@ from amundsen_application.api.freshness import v0
 from amundsen_application.base.base_data_freshness_client import BaseDataFreshnessClient
 
 local_app = create_app('amundsen_application.config.TestConfig', 'tests/templates')
-DATA_FRESHNESS_CLIENT_CLASS = 'tests.unit.api.freshness.test_v0.DataFreshnessClient'
+DATA_FRESHNESS_CLIENT = 'tests.unit.api.freshness.test_v0.DataFreshnessClient'
 
 
 class DataFreshnessClient(BaseDataFreshnessClient):
@@ -44,7 +44,7 @@ class DataFreshnessTest(unittest.TestCase):
             response = test.post('/api/freshness/v0/')
             self.assertEqual(response.status_code, HTTPStatus.NOT_IMPLEMENTED)
 
-    @unittest.mock.patch(DATA_FRESHNESS_CLIENT_CLASS + '.get_freshness_data')
+    @unittest.mock.patch(DATA_FRESHNESS_CLIENT + '.get_freshness_data')
     def test_good_client_response(self, mock_get_freshness_data: unittest.mock.Mock) -> None:
         """
         Test response
@@ -56,7 +56,7 @@ class DataFreshnessTest(unittest.TestCase):
                 'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]}
         }
 
-        local_app.config['DATA_FRESHNESS_CLIENT'] = DATA_FRESHNESS_CLIENT_CLASS
+        local_app.config['DATA_FRESHNESS_CLIENT'] = DATA_FRESHNESS_CLIENT
         response = json.dumps({'freshness_data': {
             'columns': [{}, {}],
             'data': [{'latest updated_at': '2021-07-14 13:52:51.807 +0000'}]


### PR DESCRIPTION
1. Introduce Freshness button on TableDetailPage.
2. One the endpoint is hit, it fetches the table metadata from neo4j and pass the information to data freshness client where we can adopt any kind of custom logic to determine table freshness metric
3. Unit test added for the new api's response.
4. Available in Preview Environment. 
https://amundsen-pre-2f5cd284.brexhq.dev/table_detail/production/acquirer/public/acquirer_transactions 
However, we are still relying on devprod team to merge this [#43456](https://github.com/brexhq/credit_card/pull/43456) which they will do early next week. I tested it in PE by checking out a [branch](https://github.com/brexhq/credit_card/pull/44421) from [#43456](https://github.com/brexhq/credit_card/pull/43456) and setting up the DataFreshnessClient
