### PR TITLE
[DATA-6166] Custom config for programmatic descriptions at the top

### DIFF
--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -237,7 +237,6 @@ def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
     updated_descriptions['left'] = left
     updated_descriptions['right'] = right
     updated_descriptions['other'] = other
-    logging.info(f"updated descriptions: {updated_descriptions}")
     return updated_descriptions
 
 

--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -198,6 +198,9 @@ def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
     :param prog_descriptions: A list of objects representing programmatic descriptions
     :return: A dictionary with organized programmatic_descriptions
     """
+    # we want to put source controlled / github programmatic description on top
+    # for the project of editable description
+    top = []  # type: List
     left = []  # type: List
     right = []  # type: List
     other = prog_descriptions or []  # type: List
@@ -213,6 +216,10 @@ def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
         # If config is defined for programmatic disply we organize and sort them based on the configuration
         prog_display_config = app.config['PROGRAMMATIC_DISPLAY']
         if prog_display_config:
+            top_config = prog_display_config.get('TOP', {})
+            top = [x for x in prog_descriptions if x.get('source') in top_config]
+            top.sort(key=lambda x: _sort_prog_descriptions(top_config, x))
+
             left_config = prog_display_config.get('LEFT', {})
             left = [x for x in prog_descriptions if x.get('source') in left_config]
             left.sort(key=lambda x: _sort_prog_descriptions(left_config, x))
@@ -221,11 +228,12 @@ def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
             right = [x for x in prog_descriptions if x.get('source') in right_config]
             right.sort(key=lambda x: _sort_prog_descriptions(right_config, x))
 
-            other_config = dict(filter(lambda x: x not in ['LEFT', 'RIGHT'], prog_display_config.items()))
+            other_config = dict(filter(lambda x: x not in ['TOP', 'LEFT', 'RIGHT'], prog_display_config.items()))
             other = list(filter(lambda x: x.get('source') not in left_config and x.get('source')
                                 not in right_config, prog_descriptions))
             other.sort(key=lambda x: _sort_prog_descriptions(other_config, x))
 
+    updated_descriptions['top'] = top
     updated_descriptions['left'] = left
     updated_descriptions['right'] = right
     updated_descriptions['other'] = other

--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -230,7 +230,7 @@ def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
 
             other_config = dict(filter(lambda x: x not in ['TOP', 'LEFT', 'RIGHT'], prog_display_config.items()))
             other = list(filter(lambda x: x.get('source') not in left_config and x.get('source')
-                                not in right_config, prog_descriptions))
+                                not in right_config and x.get('source') not in top_config, prog_descriptions))
             other.sort(key=lambda x: _sort_prog_descriptions(other_config, x))
 
     updated_descriptions['top'] = top

--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -237,6 +237,7 @@ def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
     updated_descriptions['left'] = left
     updated_descriptions['right'] = right
     updated_descriptions['other'] = other
+    logging.info(f"updated descriptions: {updated_descriptions}")
     return updated_descriptions
 
 

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -455,9 +455,9 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:4044823741": [
-      [80, 8, 23, "Use object destructuring.", "1142306891"],
-      [139, 23, -4311, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:3883541609": [
+      [81, 8, 23, "Use object destructuring.", "1142306891"],
+      [140, 23, -4387, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/owners/index.spec.ts:655040122": [
       [15, 0, 91, "\`../reducer\` import should occur before import of \`./reducer\`", "2216296793"],
@@ -466,8 +466,8 @@ exports[`eslint`] = {
     "js/ducks/tableMetadata/owners/sagas.ts:3725515638": [
       [7, 0, 69, "\`../types\` import should occur before import of \`./reducer\`", "3326352266"]
     ],
-    "js/ducks/tableMetadata/reducer.ts:3872576896": [
-      [416, 6, 93, "Unexpected lexical declaration in case block.", "4098864482"]
+    "js/ducks/tableMetadata/reducer.ts:4228277038": [
+      [465, 6, 93, "Unexpected lexical declaration in case block.", "4098864482"]
     ],
     "js/ducks/tags/api/v0.ts:2781466514": [
       [21, 16, -605, "Expected to return a value at the end of function \'getResourceTags\'.", "5381"]
@@ -500,8 +500,8 @@ exports[`eslint`] = {
     "js/features/ColumnList/index.spec.tsx:2138919335": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
     ],
-    "js/features/ColumnList/index.tsx:3552909395": [
-      [205, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:3692785076": [
+      [205, 2, 834, "Arrow function expected no return value.", "2539797162"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -662,7 +662,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/ListSortingDropdown/index.spec.tsx:1478300175": [
       [174, 14, 34, "Use array destructuring.", "2024515814"]
     ],
-    "js/pages/TableDetailPage/ListSortingDropdown/index.tsx:461685831": [
+    "js/pages/TableDetailPage/ListSortingDropdown/index.tsx:3178023015": [
       [62, 25, 1, "\'_\' is defined but never used.", "177658"],
       [65, 14, 204, "A control must be associated with a text label.", "3622841199"]
     ],
@@ -711,7 +711,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:4211828621": [
+    "js/pages/TableDetailPage/index.tsx:2696952062": [
       [147, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [189, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -208,13 +208,13 @@ const ExpandedRowComponent: React.FC<ExpandedRowProps> = (
       {shouldRenderDescription() && (
         <EditableSection
           title={EDITABLE_SECTION_TITLE}
-          readOnly={!rowValue.isEditable}
+          readOnly
           editText={rowValue.editText || undefined}
           editUrl={rowValue.editUrl || undefined}
         >
           <ColumnDescEditableText
             columnIndex={rowValue.col_index}
-            editable={rowValue.isEditable}
+            editable={false}
             maxLength={getMaxLength('columnDescLength')}
             value={rowValue.content.description}
           />

--- a/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -80,6 +80,7 @@ export interface ProgrammaticDescription {
   text: string;
 }
 export interface TableProgrammaticDescriptions {
+  top?: ProgrammaticDescription[];
   left?: ProgrammaticDescription[];
   right?: ProgrammaticDescription[];
   other?: ProgrammaticDescription[];

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/constants.ts
@@ -1,5 +1,5 @@
-export const NO_WATERMARK_LINE_1 = 'No valid partitions found';
-export const NO_WATERMARK_LINE_2 = 'Unknown date range';
+export const NO_WATERMARK_LINE_1 = 'Not Available';
+export const NO_WATERMARK_LINE_2 = '';
 export const LOW_WATERMARK_LABEL = 'From:';
 export const HIGH_WATERMARK_LABEL = 'To:';
 export const WATERMARK_INPUT_FORMAT = 'YYYY-MM-DD';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/index.tsx
@@ -8,8 +8,6 @@ import { Watermark } from 'interfaces';
 import { formatDate } from 'utils/dateUtils';
 import {
   HIGH_WATERMARK_LABEL,
-  NO_WATERMARK_LINE_1,
-  NO_WATERMARK_LINE_2,
   LOW_WATERMARK_LABEL,
   WATERMARK_INPUT_FORMAT,
   WatermarkType,
@@ -35,13 +33,7 @@ class WatermarkLabel extends React.Component<WatermarkLabelProps> {
 
   renderWatermarkInfo = (low: string | null, high: string | null) => {
     if (low === null && high === null) {
-      return (
-        <div className="body-2">
-          {NO_WATERMARK_LINE_1}
-          <br />
-          {NO_WATERMARK_LINE_2}
-        </div>
-      );
+      return <div className="body-2">Not Available</div>;
     }
 
     return (

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/index.tsx
@@ -8,6 +8,8 @@ import { Watermark } from 'interfaces';
 import { formatDate } from 'utils/dateUtils';
 import {
   HIGH_WATERMARK_LABEL,
+  NO_WATERMARK_LINE_1,
+  NO_WATERMARK_LINE_2,
   LOW_WATERMARK_LABEL,
   WATERMARK_INPUT_FORMAT,
   WatermarkType,
@@ -33,7 +35,13 @@ class WatermarkLabel extends React.Component<WatermarkLabelProps> {
 
   renderWatermarkInfo = (low: string | null, high: string | null) => {
     if (low === null && high === null) {
-      return <div className="body-2">Not Available</div>;
+      return (
+        <div className="body-2">
+          {NO_WATERMARK_LINE_1}
+          <br />
+          {NO_WATERMARK_LINE_2}
+        </div>
+      );
     }
 
     return (

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
@@ -7,7 +7,7 @@ export const EDIT_OWNERS_TEXT = 'Click to edit owners in';
 
 export const COLUMN_URL_KEY = 'column';
 export const DATE_RANGE_TITLE = 'Date Range';
-export const DESCRIPTION_TITLE = 'Description';
+export const DESCRIPTION_TITLE = 'Editable Description';
 export const FREQ_USERS_TITLE = 'Frequent Users';
 export const LAST_UPDATED_TITLE = 'Last Updated';
 export const OWNERS_TITLE = 'Owners';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
@@ -7,7 +7,7 @@ export const EDIT_OWNERS_TEXT = 'Click to edit owners in';
 
 export const COLUMN_URL_KEY = 'column';
 export const DATE_RANGE_TITLE = 'Date Range';
-export const DESCRIPTION_TITLE = 'Editable Description';
+export const DESCRIPTION_TITLE = 'Comment';
 export const FREQ_USERS_TITLE = 'Frequent Users';
 export const LAST_UPDATED_TITLE = 'Last Updated';
 export const OWNERS_TITLE = 'Owners';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -474,6 +474,7 @@ export class TableDetail extends React.Component<
                   severity={tableNotice.severity}
                 />
               )}
+              {this.renderProgrammaticDesc(data.programmatic_descriptions.top)}
               <EditableSection
                 title={Constants.DESCRIPTION_TITLE}
                 readOnly={!data.is_editable}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -76,7 +76,6 @@ import TableDashboardResourceList from './TableDashboardResourceList';
 import TableDescEditableText from './TableDescEditableText';
 import TableHeaderBullets from './TableHeaderBullets';
 import TableIssues from './TableIssues';
-import WatermarkLabel from './WatermarkLabel';
 import ApplicationDropdown from './ApplicationDropdown';
 import TableQualityChecksLabel from './TableQualityChecks';
 import TableReportsDropdown from './ResourceReportsDropdown';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -76,6 +76,7 @@ import TableDashboardResourceList from './TableDashboardResourceList';
 import TableDescEditableText from './TableDescEditableText';
 import TableHeaderBullets from './TableHeaderBullets';
 import TableIssues from './TableIssues';
+import WatermarkLabel from './WatermarkLabel';
 import ApplicationDropdown from './ApplicationDropdown';
 import TableQualityChecksLabel from './TableQualityChecks';
 import TableReportsDropdown from './ResourceReportsDropdown';
@@ -511,6 +512,12 @@ export class TableDetail extends React.Component<
                       </time>
                     </section>
                   )}
+                  <section className="metadata-section">
+                    <div className="section-title">
+                      {Constants.DATE_RANGE_TITLE}
+                    </div>
+                    <WatermarkLabel watermarks={data.watermarks} />
+                  </section>
                   <EditableSection title={Constants.TAG_TITLE}>
                     <TagInput
                       resourceType={ResourceType.table}
@@ -527,7 +534,7 @@ export class TableDetail extends React.Component<
                 <section className="right-panel">
                   <EditableSection
                     title={Constants.OWNERS_TITLE}
-                    readOnly={!data.is_editable}
+                    readOnly
                     editText={ownersEditText}
                     editUrl={editUrl || undefined}
                   >

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -475,20 +475,20 @@ export class TableDetail extends React.Component<
                 />
               )}
               {this.renderProgrammaticDesc(data.programmatic_descriptions.top)}
+              <span>
+                {notificationsEnabled() && <RequestDescriptionText />}
+              </span>
               <EditableSection
                 title={Constants.DESCRIPTION_TITLE}
-                readOnly={false}
+                readOnly={!data.is_editable}
                 editText={editText}
                 editUrl={editUrl || undefined}
               >
                 <TableDescEditableText
                   maxLength={getMaxLength('tableDescLength')}
                   value={data.description}
-                  editable
+                  editable={data.is_editable}
                 />
-                <span>
-                  {notificationsEnabled() && <RequestDescriptionText />}
-                </span>
               </EditableSection>
               {issueTrackingEnabled() && (
                 <section className="metadata-section">

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -477,7 +477,7 @@ export class TableDetail extends React.Component<
               {this.renderProgrammaticDesc(data.programmatic_descriptions.top)}
               <EditableSection
                 title={Constants.DESCRIPTION_TITLE}
-                readOnly={!data.is_editable}
+                readOnly={false}
                 editText={editText}
                 editUrl={editUrl || undefined}
               >

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -484,7 +484,7 @@ export class TableDetail extends React.Component<
                 <TableDescEditableText
                   maxLength={getMaxLength('tableDescLength')}
                   value={data.description}
-                  editable={data.is_editable}
+                  editable
                 />
                 <span>
                   {notificationsEnabled() && <RequestDescriptionText />}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -474,10 +474,14 @@ export class TableDetail extends React.Component<
                   severity={tableNotice.severity}
                 />
               )}
-              {this.renderProgrammaticDesc(data.programmatic_descriptions.top)}
-              <span>
-                {notificationsEnabled() && <RequestDescriptionText />}
-              </span>
+              <EditableSection title="Source Controlled Description">
+                {this.renderProgrammaticDesc(
+                  data.programmatic_descriptions.top
+                )}
+                <span>
+                  {notificationsEnabled() && <RequestDescriptionText />}
+                </span>
+              </EditableSection>
               <EditableSection
                 title={Constants.DESCRIPTION_TITLE}
                 readOnly={!data.is_editable}
@@ -512,12 +516,6 @@ export class TableDetail extends React.Component<
                       </time>
                     </section>
                   )}
-                  <section className="metadata-section">
-                    <div className="section-title">
-                      {Constants.DATE_RANGE_TITLE}
-                    </div>
-                    <WatermarkLabel watermarks={data.watermarks} />
-                  </section>
                   <EditableSection title={Constants.TAG_TITLE}>
                     <TagInput
                       resourceType={ResourceType.table}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -474,14 +474,10 @@ export class TableDetail extends React.Component<
                   severity={tableNotice.severity}
                 />
               )}
-              <EditableSection title="Source Controlled Description">
-                {this.renderProgrammaticDesc(
-                  data.programmatic_descriptions.top
-                )}
-                <span>
-                  {notificationsEnabled() && <RequestDescriptionText />}
-                </span>
-              </EditableSection>
+              {this.renderProgrammaticDesc(data.programmatic_descriptions.top)}
+              <span>
+                {notificationsEnabled() && <RequestDescriptionText />}
+              </span>
               <EditableSection
                 title={Constants.DESCRIPTION_TITLE}
                 readOnly={!data.is_editable}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

https://brexhq.atlassian.net/browse/DATA-6166

Add a section for displaying programmatic descriptions at top.
Gif available in https://github.com/brexhq/credit_card/pull/70465

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
